### PR TITLE
fix: remove python limit

### DIFF
--- a/pages/api/quote/[slugs].tsx
+++ b/pages/api/quote/[slugs].tsx
@@ -8,16 +8,6 @@ interface LooseObject {
 }
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.headers['user-agent']?.includes('python-requests')) {
-    res.setHeader('Cache-Control', 's-maxage=2592000, stale-while-revalidate');
-
-    res.status(403).json({
-      error: true,
-      message:
-        'Your limit exceeded, please email us at brapi@protonmail.com for more information',
-    });
-    return;
-  }
   const { slugs } = req.query;
   const { interval } = req.query;
   const { range } = req.query;


### PR DESCRIPTION
Last week we had a massive usage spike from a python user (1.6 million requests when our average is around 20 thousand). We almost passed our monthly budget with it. But now Vercel is sponsoring us, so we can easily afford it now.

This PR just removes the python usage limit