### PR TITLE
fix: available currency pattern

### DIFF
--- a/pages/api/v2/currency/available.ts
+++ b/pages/api/v2/currency/available.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { NextApiRequest, NextApiResponse } from 'next';
 // import { logHost } from '../../../../utils/logHost';
-import { sortObject } from '../../../../utils/sortObject';
 
 interface DataProps {
   [key: string]: string;
@@ -41,8 +40,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     return;
   }
 
+  const currenciesData = Object.keys(data).map((key) => ({
+    name: key,
+    currency: data[key],
+  }));
+
   res.status(200).json({
-    currencies: sortObject(data),
+    currencies: currenciesData,
   });
 
   // logHost(req, 'v2/crypto/available');


### PR DESCRIPTION
Closes #17 

Padroniza o endpoint `api/v2/currency/available` com `api/v2/currency/available?search=`.
Agora ambos endpoints retornam no mesmo padrão:

```json
{
  "currencies": [
    {
      "name": "USD-BRL",
      "currency": "Dólar Americano/Real Brasileiro"
    },
    {
      "name": "USD-BRLT",
      "currency": "Dólar Americano/Real Brasileiro Turismo"
    },
    {
      "name": "CAD-BRL",
      "currency": "Dólar Canadense/Real Brasileiro"
    }
    ...
  ]
}
```