### PR TITLE
feat: remove "duplicated" tickers and accepts all tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 
 Na brapi, você tem acesso à cotação em tempo real das ações da Bovespa e criptomoedas com um delay de até 15 minutos. Você tem acesso à uma API que mostra todos os dados necessarios para você desenvolver a sua própria aplicação relacionada ao mercado de ações brasileiro ou cripto. Ajudamos desenvolvedores a construir o futuro das fintechs democratizando o acesso aos dados do mercado financeiro brasileiro e de criptomoedas.
 
-Funciona com Ações comuns com final 3 e 4. Também funciona com Fundos de Investimento com final 11.
-
 Também suportamos criptomoedas e conversão de moedas
 
 - Saiba mais: [https://brapi.ga](https://brapi.ga)

--- a/pages/api/available.tsx
+++ b/pages/api/available.tsx
@@ -43,12 +43,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   );
 
   const paths = await response.data.data.map((stock: any) => {
-    const availableStock = stock.s
-      .replace('3F', '3')
-      .replace('4F', '4')
-      .replace('11F', '11')
-      .replace('6F', '6')
-      .replace('BMFBOVESPA:', '');
+    const availableStock = stock.s.replace('BMFBOVESPA:', '');
 
     return availableStock;
   });

--- a/pages/api/quote/list.tsx
+++ b/pages/api/quote/list.tsx
@@ -47,16 +47,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         left: sortBy?.toString() || 'volume',
         operation: 'nempty',
       },
-      {
-        left: 'type',
-        operation: 'equal',
-        right: 'stock',
-      },
-      {
-        left: 'subtype',
-        operation: 'equal',
-        right: 'common',
-      },
     ],
     options: {
       lang: 'pt',
@@ -96,12 +86,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         .replace(' N2', '');
     };
 
-    const availableStock = stock.s
-      .replace('3F', '3')
-      .replace('4F', '4')
-      .replace('11F', '11')
-      .replace('6F', '6')
-      .replace('BMFBOVESPA:', '');
+    const availableStock = stock.s.replace('BMFBOVESPA:', '');
 
     const cleanName = cleanString(stock.d[4]);
 

--- a/pages/docs/list.tsx
+++ b/pages/docs/list.tsx
@@ -39,12 +39,7 @@ export const getStaticProps = async () => {
   );
 
   const paths = await response.data.data.map((stock: any) => {
-    const workingStock = stock.s
-      .replace('3F', '3')
-      .replace('4F', '4')
-      .replace('11F', '11')
-      .replace('6F', '6')
-      .replace('BMFBOVESPA:', '');
+    const workingStock = stock.s.replace('BMFBOVESPA:', '');
 
     const stockImg = stock.d[0]
       ? `https://s3-symbol-logo.tradingview.com/${stock.d[0]}.svg`

--- a/pages/quotes/[slug].tsx
+++ b/pages/quotes/[slug].tsx
@@ -23,12 +23,7 @@ export const getServerSidePaths = async () => {
 
   const paths = await response.data.data
     .map((stock: any) => {
-      const workingStock = stock.s
-        .replace('3F', '3')
-        .replace('4F', '4')
-        .replace('11F', '11')
-        .replace('6F', '6')
-        .replace('BMFBOVESPA:', '');
+      const workingStock = stock.s.replace('BMFBOVESPA:', '');
 
       return { params: { slug: workingStock } };
     })


### PR DESCRIPTION
Closes #21 and #24

I don't remember why but I tried "cleaning" the ticker's symbol, so when a ticker was like `MGLU3F` it would be "cleaned" to `MGLU3`, the same as the real `MGLU3`, so it would tecnically be duplicated.

Looking closer at the trading view internal api, they also have tickers ending with 6 that work with our api, so we're keeping them