### PR TITLE
fix: crypto value is null

### DIFF
--- a/pages/api/v2/crypto/index.ts
+++ b/pages/api/v2/crypto/index.ts
@@ -50,6 +50,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           currency?.toString()?.toUpperCase() || 'BRL'
         }`,
       );
+      console.log(data);
+
       USDPriceInCurrency = data;
     }
 

--- a/pages/api/v2/crypto/index.ts
+++ b/pages/api/v2/crypto/index.ts
@@ -50,7 +50,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           currency?.toString()?.toUpperCase() || 'BRL'
         }`,
       );
-      console.log(data);
 
       USDPriceInCurrency = data;
     }
@@ -59,7 +58,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       if (currency?.toString()?.toUpperCase() == 'USD') {
         return Number(usdPrice);
       }
-      const currencyPrice = Number(USDPriceInCurrency['USD']?.bid);
+
+      const currencySelector = `USD${
+        currency?.toString()?.toUpperCase() || 'BRL'
+      }`;
+      const currencyPrice = Number(USDPriceInCurrency[currencySelector]?.bid);
 
       return currencyPrice * Number(usdPrice);
     };


### PR DESCRIPTION
Closes #30 

- The currency conversion api changed how they display data, this PR adjusts to the new format (from `USD` to `USDBRL`)