### PR TITLE
feat: make multiple calls at the same time

### DIFF
--- a/constants/validIntervals.ts
+++ b/constants/validIntervals.ts
@@ -1,0 +1,15 @@
+export const validIntervals = [
+  '1m',
+  '2m',
+  '5m',
+  '15m',
+  '30m',
+  '60m',
+  '90m',
+  '1h',
+  '1d',
+  '5d',
+  '1wk',
+  '1mo',
+  '3mo',
+];

--- a/constants/validRanges.ts
+++ b/constants/validRanges.ts
@@ -1,0 +1,13 @@
+export const validRanges = [
+  '1d',
+  '5d',
+  '1mo',
+  '3mo',
+  '6mo',
+  '1y',
+  '2y',
+  '5y',
+  '10y',
+  'ytd',
+  'max',
+];

--- a/pages/api/quote/[slugs].tsx
+++ b/pages/api/quote/[slugs].tsx
@@ -32,7 +32,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     const responseAllSlugs = async () => {
       const promises = allSlugs.map(async (slug) => {
         try {
-          return processQuoteSlugData({
+          return await processQuoteSlugData({
             slug,
             dividends,
             fundamental,

--- a/server/api/handleQuoteSlugs/index.ts
+++ b/server/api/handleQuoteSlugs/index.ts
@@ -1,0 +1,83 @@
+import { getDividendsInformation } from '~/services/getDividendsInformation';
+import { getFundamentalInformation } from '~/services/getFundamentalInformation';
+import { getHistoricalData } from '~/services/getHistoricalData';
+import { getQuoteInformation } from '~/services/getQuoteInformation';
+import { parseDefaultQuoteData } from '~/utils/parseDefaultQuoteData';
+import { validRanges } from '~/constants/validRanges';
+import { validIntervals } from '~/constants/validIntervals';
+
+const resolvedPromise = new Promise((resolve) => resolve({}));
+
+interface IProcessQuoteSlugData {
+  fundamental: boolean;
+  dividends: string;
+  shouldReturnHistoricalData: boolean;
+  interval: number;
+  range: number;
+}
+
+export const processQuoteSlugData = async ({
+  slug,
+  fundamental,
+  dividends,
+  shouldReturnHistoricalData,
+  interval,
+  range,
+}): Promise<IProcessQuoteSlugData> => {
+  const isBrazilianStock = /\d/.test(slug);
+
+  const parsedSlug = isBrazilianStock ? `${slug}.SA` : slug;
+
+  const promises = [];
+
+  promises.push(getQuoteInformation({ parsedSlug }));
+
+  promises.push(
+    fundamental === 'true'
+      ? getFundamentalInformation({ slug })
+      : resolvedPromise,
+  );
+
+  promises.push(
+    dividends === 'true' ? getDividendsInformation({ slug }) : resolvedPromise,
+  );
+
+  promises.push(
+    shouldReturnHistoricalData
+      ? getHistoricalData({
+          parsedSlug,
+          interval: interval.toString(),
+          range: range.toString(),
+        })
+      : resolvedPromise,
+  );
+
+  const [
+    data,
+    fundamentalInformation,
+    dividendsData,
+    historicalData,
+  ] = await Promise.all(
+    promises.map((promise) => promise.catch((e) => console.error(e))),
+  );
+
+  const parsedQuoteData = parseDefaultQuoteData({
+    data,
+    slug,
+  });
+
+  const quote = {
+    ...parsedQuoteData,
+    ...(shouldReturnHistoricalData && {
+      historicalDataPrice: historicalData,
+      validRanges,
+      validIntervals,
+    }),
+    ...(fundamental === 'true' && { ...fundamentalInformation }),
+    ...(dividends === 'true' && { dividendsData }),
+  };
+
+  if (Object.keys(quote).length > 0) {
+    return quote;
+  }
+};

--- a/server/api/handleQuoteSlugs/index.ts
+++ b/server/api/handleQuoteSlugs/index.ts
@@ -57,9 +57,7 @@ export const processQuoteSlugData = async ({
     fundamentalInformation,
     dividendsData,
     historicalData,
-  ] = await Promise.all(
-    promises.map((promise) => promise.catch((e) => console.error(e))),
-  );
+  ] = await Promise.all(promises);
 
   const parsedQuoteData = parseDefaultQuoteData({
     data,

--- a/server/api/handleQuoteSlugs/index.ts
+++ b/server/api/handleQuoteSlugs/index.ts
@@ -6,7 +6,7 @@ import { parseDefaultQuoteData } from '~/utils/parseDefaultQuoteData';
 import { validRanges } from '~/constants/validRanges';
 import { validIntervals } from '~/constants/validIntervals';
 
-const resolvedPromise = new Promise((resolve) => resolve({}));
+const resolvedPromise = Promise.resolve();
 
 interface IProcessQuoteSlugData {
   fundamental: boolean;

--- a/services/getHistoricalData.tsx
+++ b/services/getHistoricalData.tsx
@@ -21,7 +21,7 @@ interface IYahooFinanceResponse {
 }
 
 interface IGetHistoricalData {
-  slug: string;
+  parsedSlug: string;
   interval?: string;
   range?: string;
 }
@@ -37,12 +37,12 @@ export interface IGetHistoricalDataResponse {
 }
 
 export const getHistoricalData = async ({
-  slug,
+  parsedSlug,
   interval,
   range,
 }: IGetHistoricalData): Promise<IGetHistoricalDataResponse[]> => {
   const historicalResponse = await axios.get<IYahooFinanceResponse>(
-    `https://query1.finance.yahoo.com/v8/finance/chart/${slug}${
+    `https://query1.finance.yahoo.com/v8/finance/chart/${parsedSlug}${
       interval && range
         ? `?includePrePost=false&interval=${interval}&useYfid=true&range=${range}`
         : '?includePrePost=false&interval=1d&useYfid=true&range=1mo'

--- a/services/getQuoteInformation.ts
+++ b/services/getQuoteInformation.ts
@@ -87,15 +87,15 @@ export interface IYahooFinanceQuote {
 }
 
 interface IGetQuoteInformation {
-  slug: string;
+  parsedSlug: string;
 }
 
 export const getQuoteInformation = async ({
-  slug,
+  parsedSlug,
 }: IGetQuoteInformation): Promise<IYahooFinanceQuote> => {
   const response = await axios.get<IYahooFinanceQuoteResponse>(
-    `https://query1.finance.yahoo.com/v7/finance/options/${slug}`,
+    `https://query1.finance.yahoo.com/v7/finance/options/${parsedSlug}`,
   );
 
-  return response.data.optionChain.result[0].quote;
+  return response?.data?.optionChain?.result?.[0]?.quote;
 };

--- a/utils/parseDefaultQuoteData.ts
+++ b/utils/parseDefaultQuoteData.ts
@@ -43,7 +43,7 @@ export const parseDefaultQuoteData = ({
   slug,
   customFields,
 }: IParseDefaultQuoteData) => {
-  const { symbol, regularMarketTime, ...rest } = data;
+  const { symbol, regularMarketTime, ...rest } = data ?? {};
 
   const allFields = [...defaultFields, ...(customFields ?? [])];
 
@@ -56,6 +56,6 @@ export const parseDefaultQuoteData = ({
   return {
     ...necessaryFields,
     symbol: slug.toString().toUpperCase(),
-    regularMarketTime: new Date(data.regularMarketTime * 1000),
+    regularMarketTime: new Date(regularMarketTime * 1000),
   };
 };


### PR DESCRIPTION
- Refactors code to make multiple async calls at the same time and reduce wait times
- Performance improvements of around 50% (1.2s to between 800ms and 300ms)
- Abstracts some endpoint logic into a a handler
- Create constants file for shared constants
- Better function argument names (`slug` to `parsedSlug` in some cases could error out the function)